### PR TITLE
Use uint8_t for byte data

### DIFF
--- a/components/axp192/axp192.cpp
+++ b/components/axp192/axp192.cpp
@@ -54,7 +54,7 @@ void AXP192Component::begin(bool disableLDO2, bool disableLDO3, bool disableRTC,
     Write1Byte(0x33, 0xc0);
 
     // Depending on configuration enable LDO2, LDO3, DCDC1, DCDC3.
-    byte buf = (Read8bit(0x12) & 0xef) | 0x4D;
+    uint8_t buf = (Read8bit(0x12) & 0xef) | 0x4D;
     if(disableLDO3) buf &= ~(1<<3);
     if(disableLDO2) buf &= ~(1<<2);
     if(disableDCDC3) buf &= ~(1<<1);


### PR DESCRIPTION
A few months ago this worked fine, but re-building my projects today, seems something has changed in esphome so that `byte` isn't defined any more. I have no idea why @gonzalop didn't hit this when writing #14 - perhaps this problem is specific to some combination of esphome version + platform? I'm building on OSX/clang if that's relevant at all, perhaps it works fine with linux/gcc? o.o

Either way, it seems the rest of the codebase uses uint8_t, so I think that should probably work fine in all environments?